### PR TITLE
chore: support showing alias name

### DIFF
--- a/src/property.ts
+++ b/src/property.ts
@@ -62,7 +62,7 @@ class Property extends BaseProperty {
     }
 
     name() {
-      return this.mongoosePath.path
+      return this.mongoosePath.options.alias || this.mongoosePath.path
     }
 
     isEditable() {


### PR DESCRIPTION
For properties that are using using `alias` (for example, in a large scale database or a large collection, it's preferred to use the alias to improve the performance and get more space).

We can define the Schema with an alias like below:

```typescript
const Schema: Schema = new Schema({
  a: { type: String, alias: 'action' },
  u: { type: Types.ObjectId, ref: `User`, alias: 'user_id'}
})
```
But the AdminJS will show the shorten name in Dashboard.
This update will let AdminJS handling the alias as the property name instead.